### PR TITLE
Fixing NullPointerException in HeadersMapExtractAdapter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,12 @@
       <version>4.12</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <version>1.1.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/io/opentracing/contrib/rabbitmq/HeadersMapExtractAdapter.java
+++ b/src/main/java/io/opentracing/contrib/rabbitmq/HeadersMapExtractAdapter.java
@@ -18,6 +18,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 
+import static java.lang.String.valueOf;
 
 public class HeadersMapExtractAdapter implements TextMap {
 
@@ -28,7 +29,7 @@ public class HeadersMapExtractAdapter implements TextMap {
       return;
     }
     for (Map.Entry<String, Object> entry : headers.entrySet()) {
-      map.put(entry.getKey(), entry.getValue().toString());
+      map.put(entry.getKey(), valueOf(entry.getValue()));
     }
   }
 

--- a/src/test/java/io/opentracing/contrib/rabbitmq/HeadersMapExtractAdapterTest.java
+++ b/src/test/java/io/opentracing/contrib/rabbitmq/HeadersMapExtractAdapterTest.java
@@ -1,3 +1,16 @@
+/*
+ * Copyright 2017-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.rabbitmq;
 
 import java.util.HashMap;

--- a/src/test/java/io/opentracing/contrib/rabbitmq/HeadersMapExtractAdapterTest.java
+++ b/src/test/java/io/opentracing/contrib/rabbitmq/HeadersMapExtractAdapterTest.java
@@ -1,0 +1,65 @@
+package io.opentracing.contrib.rabbitmq;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(JUnitParamsRunner.class)
+public class HeadersMapExtractAdapterTest {
+
+    @Test
+    @Parameters(method = "emptyValues")
+    public void emptyHeadersMapExtract(Map<String, Object> inputMap) {
+        //given params
+
+        //when
+        HeadersMapExtractAdapter adapter = new HeadersMapExtractAdapter(inputMap);
+
+        //then
+        assertFalse(adapter.iterator().hasNext());
+    }
+
+    @Test
+    @Parameters(method = "nonEmptyValues")
+    public void nonEmptyHeadersMapExtract(String header, Object value, String expectedKey, String expectedValue) {
+        //given
+        Map<String, Object> inputMap = new HashMap<>();
+        inputMap.put(header, value);
+
+        //when
+        HeadersMapExtractAdapter adapter = new HeadersMapExtractAdapter(inputMap);
+
+        //then
+        assertTrue(adapter.iterator().hasNext());
+        Map.Entry<String, String> entry = adapter.iterator().next();
+        assertEquals(expectedValue, entry.getValue());
+        assertEquals(expectedKey, entry.getKey());
+    }
+
+    @Parameters
+    private Object[] emptyValues() {
+        return new Object[]{
+                new Object[]{null},
+                new Object[]{new HashMap<>()},
+        };
+    }
+
+    @Parameters
+    private Object[] nonEmptyValues() {
+        return new Object[]{
+                new Object[]{"header1", "value1",  "header1", "value1"},
+                new Object[]{"header2", "",        "header2", ""},
+                new Object[]{"header3", null,      "header3", "null"},
+                new Object[]{"header4", 1L,        "header4", "1"},
+                new Object[]{"header5", false,     "header5", "false"},
+        };
+    }
+}


### PR DESCRIPTION
## Description
Fixing NullPointerException in HeadersMapExtractAdapter
- covering changes with Unit test cases

See the stacktrace below:
```
AMQChannel(amqp://user@127.0.0.1:5672/test,3) threw an exception for channel AMQChannel(amqp://user@127.0.0.1:5672/test,3) java.lang.NullPointerException: null
    at io.opentracing.contrib.rabbitmq.HeadersMapExtractAdapter.<init>(HeadersMapExtractAdapter.java:31)
    at io.opentracing.contrib.rabbitmq.TracingUtils.extract(TracingUtils.java:31)
    at io.opentracing.contrib.rabbitmq.TracingUtils.buildChildSpan(TracingUtils.java:51)
    at io.opentracing.contrib.rabbitmq.TracingConsumer.handleDelivery(TracingConsumer.java:66)
    at com.rabbitmq.client.impl.ConsumerDispatcher$5.run(ConsumerDispatcher.java:149)
    at com.rabbitmq.client.impl.ConsumerWorkService$WorkPoolRunnable.run(ConsumerWorkService.java:104)
    at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
    at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
    at java.base/java.lang.Thread.run(Thread.java:834)```
