### PR TITLE
Set scope=provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
       <groupId>com.rabbitmq</groupId>
       <artifactId>amqp-client</artifactId>
       <version>5.7.3</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Setting the scope of the target library to "provided". It is a guarantee that the integrating codebase will provide this library, otherwise the instrumentation plugin would be moot if the codebase does not already have this library.