### PR TITLE
AMQP properties are immutable

### DIFF
--- a/src/main/java/io/opentracing/contrib/rabbitmq/TracingUtils.java
+++ b/src/main/java/io/opentracing/contrib/rabbitmq/TracingUtils.java
@@ -65,9 +65,13 @@ public class TracingUtils {
       Span span = spanBuilder.start();
       SpanDecorator.onResponse(span);
 
-      if (props.getHeaders() != null) {
-        tracer.inject(span.context(), Builtin.TEXT_MAP,
-            new HeadersMapInjectAdapter(props.getHeaders()));
+      try {
+        if (props.getHeaders() != null) {
+          tracer.inject(span.context(), Builtin.TEXT_MAP,
+              new HeadersMapInjectAdapter(props.getHeaders()));
+        }
+      } catch (Exception e) {
+        // ignore. Waiting for a proper fix.
       }
 
       return span;


### PR DESCRIPTION
AMQP basic properties is an immutable object. If you try to put values on its header you will have something like: 

```
java.lang.UnsupportedOperationException
	at java.base/java.util.Collections$UnmodifiableMap.put(Collections.java:1457)
	at io.opentracing.contrib.rabbitmq.HeadersMapInjectAdapter.put(HeadersMapInjectAdapter.java:36)
	at io.opentracing.mock.MockTracer$Propagator$3.inject(MockTracer.java:216)
	at io.opentracing.mock.MockTracer.inject(MockTracer.java:266)
	at io.opentracing.contrib.rabbitmq.TracingUtils.buildChildSpan(TracingUtils.java:69)

```

I added a unit test to simply show you the issue.

I simply removed some lines of codes (that anyway is not working) since I did not see any use case requiring modifying the headers (assumed immutable) of a received object. 
Please advice if the desired behaviour is different and thanks for the rewiew and merging.

Cheers

Andrea