### PR TITLE
Do not wrap channel in cases when it could not be created

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,12 @@
       <version>3.1.6</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>3.3.3</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/io/opentracing/contrib/rabbitmq/TracingConnection.java
+++ b/src/main/java/io/opentracing/contrib/rabbitmq/TracingConnection.java
@@ -79,12 +79,14 @@ public class TracingConnection implements Connection {
 
   @Override
   public Channel createChannel() throws IOException {
-    return new TracingChannel(connection.createChannel(), tracer);
+    Channel channel = connection.createChannel();
+    return channel != null ? new TracingChannel(channel, tracer) : null;
   }
 
   @Override
   public Channel createChannel(int channelNumber) throws IOException {
-    return new TracingChannel(connection.createChannel(channelNumber), tracer);
+    Channel channel = connection.createChannel(channelNumber);
+    return channel != null ? new TracingChannel(channel, tracer) : null;
   }
 
   @Override

--- a/src/test/java/io/opentracing/contrib/rabbitmq/TracingConnectionTest.java
+++ b/src/test/java/io/opentracing/contrib/rabbitmq/TracingConnectionTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2017-2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.rabbitmq;
+
+import com.rabbitmq.client.Channel;
+import com.rabbitmq.client.Connection;
+import io.opentracing.mock.MockTracer;
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TracingConnectionTest {
+
+  @Test
+  public void shouldNotWrapNullChannel() throws Exception {
+    Connection connection = mock(Connection.class);
+    when(connection.createChannel()).thenReturn(null);
+    when(connection.createChannel(1)).thenReturn(null);
+
+    TracingConnection tracingConnection = new TracingConnection(connection, new MockTracer());
+    assertNull(tracingConnection.createChannel());
+    assertNull(tracingConnection.createChannel(1));
+  }
+
+  @Test
+  public void shouldWrapNotNullChannel() throws Exception {
+    Connection connection = mock(Connection.class);
+    Channel channel = mock(Channel.class);
+    when(connection.createChannel()).thenReturn(channel);
+    when(connection.createChannel(1)).thenReturn(channel);
+
+    TracingConnection tracingConnection = new TracingConnection(connection, new MockTracer());
+    assertNotNull(tracingConnection.createChannel());
+    assertNotNull(tracingConnection.createChannel(1));
+  }
+
+}


### PR DESCRIPTION
# Description 

Native method `Connection.createChannel` can return `null` when no channel is available (for example in cases when maximum number of channels has already been reached). In such cases `TracingConnection` should also return `null` to follow the same method contract.

```
    /**
     * Create a new channel, using an internally allocated channel number.
     * If <a href="https://www.rabbitmq.com/api-guide.html#recovery">automatic connection recovery</a>
     * is enabled, the channel returned by this method will be {@link Recoverable}.
     * <p>
     * Use {@link #openChannel()} if you want to use an {@link Optional} to deal
     * with a {@null} value.
     *
     * @return a new channel descriptor, or null if none is available
     * @throws IOException if an I/O problem is encountered
     */
```

Solution is to wrap with `TracingChannel` only in cases when channel could be succesfuly created. Without this any subsequent channel related calls end up with `NullPointerException`.

# Summary:
- `null` channels are no longer wrapped with `TracingChannel`
- added test cases for this