### PR TITLE
REL-1526 - Fix context propagation for async communication

### DIFF
--- a/src/main/java/io/opentracing/contrib/rabbitmq/HeadersMapInjectAdapter.java
+++ b/src/main/java/io/opentracing/contrib/rabbitmq/HeadersMapInjectAdapter.java
@@ -13,9 +13,11 @@
  */
 package io.opentracing.contrib.rabbitmq;
 
-import io.opentracing.propagation.TextMap;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+
+import io.opentracing.propagation.TextMap;
 
 
 public class HeadersMapInjectAdapter implements TextMap {
@@ -23,7 +25,9 @@ public class HeadersMapInjectAdapter implements TextMap {
   private final Map<String, Object> headers;
 
   public HeadersMapInjectAdapter(Map<String, Object> headers) {
-    this.headers = headers;
+    // CNC-194 - SR workaround for immutable headers map
+      // Version: opentracing-rabbitmq-client:0.1.12-SR1
+    this.headers = new HashMap<>(headers);
   }
 
   @Override


### PR DESCRIPTION
Previous fix was handling cases when trace context was restored from
event on consumer side. Due to unknown reasons this code that was
manipulating message headers was invoked (https://github
.com/opentracing-contrib/java-rabbitmq-client/blob/master/src/main/java
/io/opentracing/contrib/rabbitmq/TracingUtils.java#L67-L74).

Unfortunately, this fix was breaking injecting tracing context on
producer side, which effectively was killing context propagation.